### PR TITLE
Fix Issue #6

### DIFF
--- a/src/main/java/com/github/dylon/liblevenshtein/collection/dawg/DawgNode.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/collection/dawg/DawgNode.java
@@ -82,24 +82,6 @@ public class DawgNode implements IDawgNode<DawgNode> {
    * {@inheritDoc}
    */
   @Override
-  public int hashCode() {
-    // NOTE: It looks like this gets called twice (consecutively) during
-    // construction of the DAWG dictionary.
-    // NOTE: An assumption is made that edges is sorted.
-    final HashCodeBuilder builder = new HashCodeBuilder(8777, 4343);
-    for (val entry : edges.char2ObjectEntrySet()) {
-      final char label = entry.getCharKey();
-      final DawgNode target = entry.getValue();
-      builder.append(label);
-      builder.append(target);
-    }
-    return builder.toHashCode();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
   public String toString() {
     final StringBuilder buffer = new StringBuilder();
     buffer.append("DawgNode{");

--- a/src/test/java/com/github/dylon/liblevenshtein/levenshtein/CollisionInFinalNodesTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/levenshtein/CollisionInFinalNodesTest.java
@@ -1,0 +1,41 @@
+package com.github.dylon.liblevenshtein.levenshtein;
+
+import com.github.dylon.liblevenshtein.levenshtein.factory.TransducerBuilder;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertTrue;
+
+public class CollisionInFinalNodesTest {
+
+    @Test
+    public void testZeroDistance() {
+        List<String> mockDictionary = new ArrayList<String>();
+
+        mockDictionary.add("Representatives");
+        mockDictionary.add("Resource");
+        mockDictionary.add("Resources");
+
+        final ITransducer<Candidate> transducer = new TransducerBuilder()
+                .algorithm(Algorithm.TRANSPOSITION)
+                .defaultMaxDistance(2)
+                .dictionary(mockDictionary)
+                .build();
+
+        for(String query: mockDictionary) {
+
+            boolean exactMatchFound = false;
+
+            for(Candidate candidate : transducer.transduce(query)) {
+                if(candidate.distance() == 0) {
+                    exactMatchFound = true;
+                    break;
+                }
+            }
+
+            assertTrue(exactMatchFound);
+        }
+    }
+}


### PR DESCRIPTION
DawgNode used custom hashCode implementation and in some cases finalNodes hasn't got all finalNodes because it is HashSet and last one use hasCode for compare nodes.

In case when node will be updated after marked as final nodes, Set doesn't update node and has @superharry case.