### PR TITLE
Multiple code improvements - squid:S1118, squid:S106

### DIFF
--- a/src/main/java/com/github/dylon/liblevenshtein/collection/dawg/AbstractDawg.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/collection/dawg/AbstractDawg.java
@@ -28,6 +28,7 @@ import it.unimi.dsi.fastutil.chars.CharIterator;
 
 import com.github.dylon.liblevenshtein.collection.dawg.factory.IDawgNodeFactory;
 import com.github.dylon.liblevenshtein.collection.dawg.factory.IPrefixFactory;
+import java.util.logging.Logger;
 
 /**
  * Provides common logic for all my Dawg implementations.  Currently, there is
@@ -44,6 +45,8 @@ public abstract class AbstractDawg
                IFinalFunction<DawgNode>,
                ITransitionFunction<DawgNode>,
                Serializable {
+
+  private static final Logger log = Logger.getLogger(AbstractDawg.class.getName());
 
   private static final long serialVersionUID = 1L;
 
@@ -136,7 +139,7 @@ public abstract class AbstractDawg
     int counter = 0;
     for (final String term : terms) {
       if (++counter % 10000 == 0) {
-        System.out.println(counter + " lines of " + terms.size());
+        log.info(counter + " lines of " + terms.size());
       }
       if (!add(term)) return false;
     }

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/factory/CandidateFactory.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/factory/CandidateFactory.java
@@ -16,6 +16,8 @@ public abstract class CandidateFactory<CandidateType>
 
   private static final long serialVersionUID = 1L;
 
+  private CandidateFactory() {}
+
   /**
    * Builds instances of {@link Candidate}, with the dictionary term and its
    * Levenshtein distance from the query term.

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/factory/PositionFactory.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/factory/PositionFactory.java
@@ -11,6 +11,8 @@ public abstract class PositionFactory implements IPositionFactory, Serializable 
 
 	private static final long serialVersionUID = 1L;
 
+  private PositionFactory() {}
+
   /**
    * Builds position vectors for the standard algorithm.
    * @author Dylon Edwards

--- a/src/task/java/com/github/dylon/liblevenshtein/task/GenerateReadme.java
+++ b/src/task/java/com/github/dylon/liblevenshtein/task/GenerateReadme.java
@@ -5,12 +5,18 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.logging.Logger;
 
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.STGroupDir;
 import org.stringtemplate.v4.ST;
 
 public class GenerateReadme {
+
+  private static final Logger log = Logger.getLogger(GenerateReadme.class.getName());
+
+  private GenerateReadme() {}
+
   public static void main(final String... args) throws IOException  {
     int argsIdx = 0;
 
@@ -39,7 +45,7 @@ public class GenerateReadme {
     template.add("javaSourceVersion", javaSourceVersion);
     template.add("javaTargetVersion", javaTargetVersion);
 
-    System.out.printf("%nRendering template [README] to [%s]%n", readmePath);
+    log.info(String.format("%nRendering template [README] to [%s]%n", readmePath));
     final String readme = template.render() + "\n";
     Files.write(readmePath, readme.getBytes(StandardCharsets.UTF_8));
   }

--- a/src/task/java/com/github/dylon/liblevenshtein/task/GenerateSyntasticConfig.java
+++ b/src/task/java/com/github/dylon/liblevenshtein/task/GenerateSyntasticConfig.java
@@ -11,6 +11,9 @@ import org.stringtemplate.v4.STGroupDir;
 import org.stringtemplate.v4.ST;
 
 public class GenerateSyntasticConfig {
+
+  private GenerateSyntasticConfig() {}
+
   public static void main(final String... args) throws IOException {
     final String classpath = args[0];
     final Path configPath = Paths.get(args[1]);

--- a/src/task/java/com/github/dylon/liblevenshtein/task/GenerateWikidoc.java
+++ b/src/task/java/com/github/dylon/liblevenshtein/task/GenerateWikidoc.java
@@ -5,12 +5,18 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.logging.Logger;
 
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.STGroupDir;
 import org.stringtemplate.v4.ST;
 
 public class GenerateWikidoc {
+
+  private static final Logger log = Logger.getLogger(GenerateReadme.class.getName());
+
+  private GenerateWikidoc() {}
+
   public static void main(final String... args) throws IOException  {
     int argsIdx = 0;
 
@@ -33,7 +39,7 @@ public class GenerateWikidoc {
       "usage"
     };
 
-    System.out.println();
+    log.info("\n");
     for (final String templateName : templateNames) {
       final ST template = group.getInstanceOf(templateName);
 
@@ -52,8 +58,8 @@ public class GenerateWikidoc {
 
       final String wikidoc = template.render() + "\n";
       final Path wikidocPath = wikidocDir.resolve(templateName + ".java.md");
-      System.out.printf("Rendering template [%s] to [%s]%n",
-          templateName, wikidocPath);
+      log.info(String.format("Rendering template [%s] to [%s]%n",
+          templateName, wikidocPath));
       Files.write(wikidocPath, wikidoc.getBytes(StandardCharsets.UTF_8));
     }
   }

--- a/src/test/java/com/github/dylon/liblevenshtein/levenshtein/StateTransitionFunctionTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/levenshtein/StateTransitionFunctionTest.java
@@ -72,74 +72,74 @@ public class StateTransitionFunctionTest {
     characteristicVector[0] = false;
     characteristicVector[1] = false;
     characteristicVector[2] = false;
-    validate(A(i), C(i), characteristicVector);
-    validate(B(i), null, characteristicVector);
-    validate(C(i), null, characteristicVector);
-    validate(D(i), null, characteristicVector);
-    validate(E(i), null, characteristicVector);
+    validate(a(i), c(i), characteristicVector);
+    validate(b(i), null, characteristicVector);
+    validate(c(i), null, characteristicVector);
+    validate(d(i), null, characteristicVector);
+    validate(e(i), null, characteristicVector);
 
     characteristicVector[0] = true;
     characteristicVector[1] = false;
     characteristicVector[2] = false;
-    validate(A(i), A(1+i), characteristicVector);
-    validate(B(i), B(1+i), characteristicVector);
-    validate(C(i), B(1+i), characteristicVector);
-    validate(D(i), B(1+i), characteristicVector);
-    validate(E(i), B(1+i), characteristicVector);
+    validate(a(i), a(1+i), characteristicVector);
+    validate(b(i), b(1+i), characteristicVector);
+    validate(c(i), b(1+i), characteristicVector);
+    validate(d(i), b(1+i), characteristicVector);
+    validate(e(i), b(1+i), characteristicVector);
 
     characteristicVector[0] = false;
     characteristicVector[1] = true;
     characteristicVector[2] = false;
-    validate(A(i), E(i), characteristicVector);
-    validate(B(i), null, characteristicVector);
-    validate(C(i), B(2+i), characteristicVector);
-    validate(D(i), null, characteristicVector);
-    validate(E(i), B(2+i), characteristicVector);
+    validate(a(i), e(i), characteristicVector);
+    validate(b(i), null, characteristicVector);
+    validate(c(i), b(2+i), characteristicVector);
+    validate(d(i), null, characteristicVector);
+    validate(e(i), b(2+i), characteristicVector);
 
     characteristicVector[0] = false;
     characteristicVector[1] = false;
     characteristicVector[2] = true;
-    validate(A(i), C(i), characteristicVector);
-    validate(B(i), null, characteristicVector);
-    validate(C(i), null, characteristicVector);
-    validate(D(i), B(3+i), characteristicVector);
-    validate(E(i), B(3+i), characteristicVector);
+    validate(a(i), c(i), characteristicVector);
+    validate(b(i), null, characteristicVector);
+    validate(c(i), null, characteristicVector);
+    validate(d(i), b(3+i), characteristicVector);
+    validate(e(i), b(3+i), characteristicVector);
 
     characteristicVector[0] = true;
     characteristicVector[1] = true;
     characteristicVector[2] = false;
-    validate(A(i), A(1+i), characteristicVector);
-    validate(B(i), B(1+i), characteristicVector);
-    validate(C(i), C(1+i), characteristicVector);
-    validate(D(i), B(1+i), characteristicVector);
-    validate(E(i), C(1+i), characteristicVector);
+    validate(a(i), a(1+i), characteristicVector);
+    validate(b(i), b(1+i), characteristicVector);
+    validate(c(i), c(1+i), characteristicVector);
+    validate(d(i), b(1+i), characteristicVector);
+    validate(e(i), c(1+i), characteristicVector);
 
     characteristicVector[0] = true;
     characteristicVector[1] = false;
     characteristicVector[2] = true;
-    validate(A(i), A(1+i), characteristicVector);
-    validate(B(i), B(1+i), characteristicVector);
-    validate(C(i), B(1+i), characteristicVector);
-    validate(D(i), D(1+i), characteristicVector);
-    validate(E(i), D(1+i), characteristicVector);
+    validate(a(i), a(1+i), characteristicVector);
+    validate(b(i), b(1+i), characteristicVector);
+    validate(c(i), b(1+i), characteristicVector);
+    validate(d(i), d(1+i), characteristicVector);
+    validate(e(i), d(1+i), characteristicVector);
 
     characteristicVector[0] = false;
     characteristicVector[1] = true;
     characteristicVector[2] = true;
-    validate(A(i), E(i), characteristicVector);
-    validate(B(i), null, characteristicVector);
-    validate(C(i), B(2+i), characteristicVector);
-    validate(D(i), B(3+i), characteristicVector);
-    validate(E(i), C(2+i), characteristicVector);
+    validate(a(i), e(i), characteristicVector);
+    validate(b(i), null, characteristicVector);
+    validate(c(i), b(2+i), characteristicVector);
+    validate(d(i), b(3+i), characteristicVector);
+    validate(e(i), c(2+i), characteristicVector);
 
     characteristicVector[0] = true;
     characteristicVector[1] = true;
     characteristicVector[2] = true;
-    validate(A(i), A(1+i), characteristicVector);
-    validate(B(i), B(1+i), characteristicVector);
-    validate(C(i), C(1+i), characteristicVector);
-    validate(D(i), D(1+i), characteristicVector);
-    validate(E(i), E(1+i), characteristicVector);
+    validate(a(i), a(1+i), characteristicVector);
+    validate(b(i), b(1+i), characteristicVector);
+    validate(c(i), c(1+i), characteristicVector);
+    validate(d(i), d(1+i), characteristicVector);
+    validate(e(i), e(1+i), characteristicVector);
   }
 
   @Test
@@ -152,48 +152,48 @@ public class StateTransitionFunctionTest {
 
     characteristicVector[0] = false;
     characteristicVector[1] = false;
-    validate(A(i), C(i), characteristicVector);
-    validate(B(i), null, characteristicVector);
-    validate(C(i), null, characteristicVector);
-    validate(D(i), null, characteristicVector);
-    validate(E(i), null, characteristicVector);
+    validate(a(i), c(i), characteristicVector);
+    validate(b(i), null, characteristicVector);
+    validate(c(i), null, characteristicVector);
+    validate(d(i), null, characteristicVector);
+    validate(e(i), null, characteristicVector);
 
     characteristicVector[0] = true;
     characteristicVector[1] = false;
-    validate(A(i), A(1+i), characteristicVector);
-    validate(B(i), B(1+i), characteristicVector);
-    validate(C(i), B(1+i), characteristicVector);
-    validate(D(i), B(1+i), characteristicVector);
-    validate(E(i), B(1+i), characteristicVector);
+    validate(a(i), a(1+i), characteristicVector);
+    validate(b(i), b(1+i), characteristicVector);
+    validate(c(i), b(1+i), characteristicVector);
+    validate(d(i), b(1+i), characteristicVector);
+    validate(e(i), b(1+i), characteristicVector);
 
     characteristicVector[0] = false;
     characteristicVector[1] = true;
-    validate(A(i), E(i), characteristicVector);
-    validate(B(i), null, characteristicVector);
-    validate(C(i), B(2+i), characteristicVector);
-    validate(D(i), null, characteristicVector);
-    validate(E(i), B(2+i), characteristicVector);
+    validate(a(i), e(i), characteristicVector);
+    validate(b(i), null, characteristicVector);
+    validate(c(i), b(2+i), characteristicVector);
+    validate(d(i), null, characteristicVector);
+    validate(e(i), b(2+i), characteristicVector);
 
     characteristicVector[0] = true;
     characteristicVector[1] = true;
-    validate(A(i), A(1+i), characteristicVector);
-    validate(B(i), B(1+i), characteristicVector);
-    validate(C(i), C(1+i), characteristicVector);
-    validate(D(i), B(1+i), characteristicVector);
-    validate(E(i), C(1+i), characteristicVector);
+    validate(a(i), a(1+i), characteristicVector);
+    validate(b(i), b(1+i), characteristicVector);
+    validate(c(i), c(1+i), characteristicVector);
+    validate(d(i), b(1+i), characteristicVector);
+    validate(e(i), c(1+i), characteristicVector);
 
     i = W - 1;
     Arrays.fill(characteristicVector, false);
 
     characteristicVector[0] = false;
-    validate(A(i), C(i), characteristicVector);
-    validate(B(i), null, characteristicVector);
-    validate(C(i), null, characteristicVector);
+    validate(a(i), c(i), characteristicVector);
+    validate(b(i), null, characteristicVector);
+    validate(c(i), null, characteristicVector);
 
     characteristicVector[0] = true;
-    validate(A(i), A(1+i), characteristicVector);
-    validate(B(i), B(1+i), characteristicVector);
-    validate(C(i), B(1+i), characteristicVector);
+    validate(a(i), a(1+i), characteristicVector);
+    validate(b(i), b(1+i), characteristicVector);
+    validate(c(i), b(1+i), characteristicVector);
 
     i = W;
     Arrays.fill(characteristicVector, false);
@@ -205,8 +205,8 @@ public class StateTransitionFunctionTest {
     // figure out what I'm doing wrong ...
     //
     //validate(A(i), B(i), characteristicVector);
-    validate(A(i), C(i), characteristicVector);
-    validate(B(i), null, characteristicVector);
+    validate(a(i), c(i), characteristicVector);
+    validate(b(i), null, characteristicVector);
   }
 
   private void validate(
@@ -217,7 +217,7 @@ public class StateTransitionFunctionTest {
     assertEquals(actualOutput, expectedOutput);
   }
 
-  private IState A(final int i) {
+  private IState a(final int i) {
     if (0 <= i && i <= W) {
       return stateFactory.build(
           positionFactory.build(i,0));
@@ -226,7 +226,7 @@ public class StateTransitionFunctionTest {
     return null;
   }
 
-  private IState B(final int i) {
+  private IState b(final int i) {
     if (0 <= i && i <= W) {
       return stateFactory.build(
           positionFactory.build(i,1));
@@ -235,7 +235,7 @@ public class StateTransitionFunctionTest {
     return null;
   }
 
-  private IState C(final int i) {
+  private IState c(final int i) {
     // [NOTE] :: In the paper, this should not be defined when i = W, but from
     // my experiments it seems to be the appropriate image of A(i) when i = W.
     //
@@ -251,7 +251,7 @@ public class StateTransitionFunctionTest {
     //return null;
   }
 
-  private IState D(final int i) {
+  private IState d(final int i) {
     if (0 <= i && i <= W - 2) {
       return stateFactory.build(
           positionFactory.build(i,1),
@@ -261,7 +261,7 @@ public class StateTransitionFunctionTest {
     return null;
   }
 
-  private IState E(final int i) {
+  private IState e(final int i) {
     if (0 <= i && i <= W - 2) {
       return stateFactory.build(
           positionFactory.build(i,1),


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S106 - Standard outputs should not be used directly to log
anything.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S106
Please let me know if you have any questions.
George Kankava