### PR TITLE
Multiple code improvements - squid:S1854, squid:UselessParenthesesCheck, squid:HiddenFieldCheck, squid:S1192, squid:S1213, squid:S2293

### DIFF
--- a/src/main/java/com/github/dylon/liblevenshtein/collection/AbstractIterator.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/collection/AbstractIterator.java
@@ -31,9 +31,9 @@ public abstract class AbstractIterator<Type> implements Iterator<Type> {
   @Override
   public Type next() {
     advance();
-    final Type next = this.next;
+    final Type nextLocal = this.next;
     this.next = null;
-    return next;
+    return nextLocal;
   }
 
   /**

--- a/src/main/java/com/github/dylon/liblevenshtein/collection/dawg/DawgIterator.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/collection/dawg/DawgIterator.java
@@ -55,8 +55,8 @@ public class DawgIterator extends AbstractIterator<String> {
   @Override
   protected void advance() {
     if (null == next && !prefixes.isEmpty()) {
-      DawgNode node = null;
-      String value = null;
+      DawgNode node;
+      String value;
 
       do {
         final Prefix<DawgNode> prefix = prefixes.poll();

--- a/src/main/java/com/github/dylon/liblevenshtein/collection/dawg/SortedDawg.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/collection/dawg/SortedDawg.java
@@ -103,7 +103,7 @@ public class SortedDawg extends AbstractDawg {
       final int size,
       @NonNull final DawgNode root) {
     super(new PrefixFactory<DawgNode>(), new DawgNodeFactory(), root, size);
-    this.transitionFactory = new TransitionFactory<DawgNode>();
+    this.transitionFactory = new TransitionFactory<>();
   }
 
   /**

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/CandidateCollection.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/CandidateCollection.java
@@ -60,8 +60,8 @@ public abstract class CandidateCollection<Type>
     // TODO: Consider specializing the data struction by <Type>, such as using
     // an unsorted Dawg for <Type=String>, etc.
     this.candidates = (maxCandidates < Integer.MAX_VALUE)
-      ? new ArrayList<Type>(maxCandidates)
-      : new ArrayList<Type>();
+      ? new ArrayList<>(maxCandidates)
+      : new ArrayList<>();
   }
 
   /**

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/LazyTransducerCollection.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/LazyTransducerCollection.java
@@ -241,7 +241,7 @@ public class LazyTransducerCollection<DictionaryNode, CandidateType>
     final boolean[] characteristicVector = new boolean[k];
 
     for (int j = 0; j < k; ++j) {
-      characteristicVector[j] = (x == term.charAt(i + j));
+      characteristicVector[j] = x == term.charAt(i + j);
     }
 
     return characteristicVector;

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/MergeAndSplitPositionTransitionFunction.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/MergeAndSplitPositionTransitionFunction.java
@@ -31,31 +31,36 @@ public class MergeAndSplitPositionTransitionFunction
       if (h <= w - 2) {
         if (characteristicVector[h]) {
           return stateFactory.build(
-              positionFactory.build((i + 1), e, 0));
+              positionFactory.build(i + 1, e, 0)
+          );
         }
 
         return stateFactory.build(
-            positionFactory.build(i, (e + 1), 0),
-            positionFactory.build(i, (e + 1), 1),
-            positionFactory.build((i + 1), (e + 1), 0),
-            positionFactory.build((i + 2), (e + 1), 0));
+            positionFactory.build(i, e + 1, 0),
+            positionFactory.build(i, e + 1, 1),
+            positionFactory.build(i + 1, e + 1, 0),
+            positionFactory.build(i + 2, e + 1, 0)
+        );
       }
 
       if (h == w - 1) {
         if (characteristicVector[h]) {
           return stateFactory.build(
-              positionFactory.build((i + 1), e, 0));
+              positionFactory.build(i + 1, e, 0)
+          );
         }
 
         return stateFactory.build(
-            positionFactory.build(i, (e + 1), 0),
-            positionFactory.build(i, (e + 1), 1),
-            positionFactory.build((i + 1), (e + 1), 0));
+            positionFactory.build(i, e + 1, 0),
+            positionFactory.build(i, e + 1, 1),
+            positionFactory.build(i + 1, e + 1, 0)
+        );
       }
 
       // else, h == w
       return stateFactory.build(
-          positionFactory.build(i, (e + 1), 0));
+          positionFactory.build(i, e + 1, 0)
+      );
     }
 
     if (e < n) {
@@ -63,54 +68,63 @@ public class MergeAndSplitPositionTransitionFunction
         if (s == 0) {
           if (characteristicVector[h]) {
             return stateFactory.build(
-                positionFactory.build((i + 1), e, 0));
+                positionFactory.build(i + 1, e, 0)
+            );
           }
 
           return stateFactory.build(
-              positionFactory.build(i, (e + 1), 0),
-              positionFactory.build(i, (e + 1), 1),
-              positionFactory.build((i + 1), (e + 1), 0),
-              positionFactory.build((i + 2), (e + 1), 0));
+              positionFactory.build(i, e + 1, 0),
+              positionFactory.build(i, e + 1, 1),
+              positionFactory.build(i + 1, e + 1, 0),
+              positionFactory.build(i + 2, e + 1, 0)
+          );
         }
 
         return stateFactory.build(
-            positionFactory.build((i + 1), e, 0));
+            positionFactory.build(i + 1, e, 0)
+        );
       }
 
       if (h == w - 1) {
         if (s == 0) {
           if (characteristicVector[h]) {
             return stateFactory.build(
-                positionFactory.build((i + 1), e, 0));
+                positionFactory.build(i + 1, e, 0)
+            );
           }
 
           return stateFactory.build(
-              positionFactory.build(i, (e + 1), 0),
-              positionFactory.build(i, (e + 1), 1),
-              positionFactory.build((i + 1), (e + 1), 0));
+              positionFactory.build(i, e + 1, 0),
+              positionFactory.build(i, e + 1, 1),
+              positionFactory.build(i + 1, e + 1, 0)
+          );
         }
 
         return stateFactory.build(
-            positionFactory.build((i + 1), e, 0));
+            positionFactory.build(i + 1, e, 0)
+        );
       }
 
       // else, h == w
       return stateFactory.build(
-          positionFactory.build(i, (e + 1), 0));
+          positionFactory.build(i, e + 1, 0)
+      );
     }
 
     if (h <= w - 1) {
       if (s == 0) {
         if (characteristicVector[h]) {
           return stateFactory.build(
-              positionFactory.build((i + 1), n, 0));
+              positionFactory.build(i + 1, n, 0)
+          );
         }
 
         return null;
       }
 
       return stateFactory.build(
-          positionFactory.build((i + 1), e, 0));
+          positionFactory.build(i + 1, e, 0)
+      );
     }
 
     // else, h == w

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/StandardPositionTransitionFunction.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/StandardPositionTransitionFunction.java
@@ -32,46 +32,53 @@ public class StandardPositionTransitionFunction
           ? n - e + 1
           : Integer.MAX_VALUE;
         final int b = w - h;
-        final int k = (a < b) ? a : b;
+        final int k = a < b ? a : b;
         final int j = indexOf(characteristicVector, k, h);
 
         if (0 == j) {
           return stateFactory.build(
-              positionFactory.build((1 + i), e));
+              positionFactory.build(1 + i, e)
+          );
         }
 
         if (j > 0) {
           return stateFactory.build(
-              positionFactory.build(i, (e + 1)),
-              positionFactory.build((i + 1), (e + 1)),
-              positionFactory.build((i + j + 1), (e + j)));
+              positionFactory.build(i, e + 1),
+              positionFactory.build(i + 1, e + 1),
+              positionFactory.build(i + j + 1, e + j)
+          );
         }
 
         // else, j < 0
         return stateFactory.build(
-            positionFactory.build(i, (e + 1)),
-            positionFactory.build((i + 1), (e + 1)));
+            positionFactory.build(i, e + 1),
+            positionFactory.build(i + 1, e + 1)
+        );
       }
 
       if (h == w - 1) {
         if (characteristicVector[h]) {
           return stateFactory.build(
-              positionFactory.build((i + 1), e));
+              positionFactory.build(i + 1, e)
+          );
         }
 
         return stateFactory.build(
-            positionFactory.build(i, (e + 1)),
-            positionFactory.build((i + 1), (e + 1)));
+            positionFactory.build(i, e + 1),
+            positionFactory.build(i + 1, e + 1)
+        );
       }
 
       // else, h == w
       return stateFactory.build(
-          positionFactory.build(i, (e + 1)));
+          positionFactory.build(i, e + 1)
+      );
     }
 
     if ((e == n) && (h <= w - 1) && characteristicVector[h]) {
       return stateFactory.build(
-          positionFactory.build((i + 1), n));
+          positionFactory.build(i + 1, n)
+      );
     }
 
     return null;

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/State.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/State.java
@@ -204,19 +204,19 @@ public class State implements IState, Serializable {
           "No elements at index: " + innerIndex);
     }
 
-    final Element<int[]> inner = this.inner;
+    final Element<int[]> innerLocal = this.inner;
 
-    if (null != inner.next()) {
-      this.inner = inner.next();
+    if (null != innerLocal.next()) {
+      this.inner = innerLocal.next();
 
-      if (null != inner.prev()) {
-        inner.prev().next(inner.next());
+      if (null != innerLocal.prev()) {
+        innerLocal.prev().next(innerLocal.next());
       }
 
-      this.inner.prev(inner.prev());
+      this.inner.prev(innerLocal.prev());
     }
     else {
-      this.inner = inner.prev();
+      this.inner = innerLocal.prev();
 
       if (null != this.inner) {
         this.inner.next(null);
@@ -225,15 +225,15 @@ public class State implements IState, Serializable {
       innerIndex -= 1;
     }
 
-    if (head == inner) {
+    if (head == innerLocal) {
       head = head.next();
     }
 
-    if (tail == inner) {
+    if (tail == innerLocal) {
       tail = tail.prev();
     }
 
-    final int[] position = inner.value();
+    final int[] position = innerLocal.value();
     size -= 1;
 
     return position;
@@ -244,11 +244,11 @@ public class State implements IState, Serializable {
    */
   @Override
   public void clear() {
-    Element<int[]> tail = this.tail;
+    Element<int[]> tailLocal = this.tail;
 
-    while (null != tail) {
-      final Element<int[]> prev = tail.prev();
-      tail = prev;
+    while (null != tailLocal) {
+      final Element<int[]> prev = tailLocal.prev();
+      tailLocal = prev;
     }
 
     this.size = 0;

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/SubsumesFunction.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/SubsumesFunction.java
@@ -76,7 +76,7 @@ public abstract class SubsumesFunction implements ISubsumesFunction, Serializabl
 
       if (s == 1) {
         if (t == 1) {
-          return (i == j);
+          return i == j;
         }
 
         return (f == n) && (i == j);

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/TranspositionPositionTransitionFunction.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/TranspositionPositionTransitionFunction.java
@@ -39,39 +39,46 @@ public class TranspositionPositionTransitionFunction
         switch (j) {
           case 0:
             return stateFactory.build(
-                positionFactory.build((i + 1), 0, 0));
+                positionFactory.build(i + 1, 0, 0)
+            );
           case 1:
             return stateFactory.build(
                 positionFactory.build(i, 1, 0),
                 positionFactory.build(i, 1, 1),
-                positionFactory.build((i + 1), 1, 0),
-                positionFactory.build((i + 2), 1, 0));
+                positionFactory.build(i + 1, 1, 0),
+                positionFactory.build(i + 2, 1, 0)
+            );
           case -1:
             return stateFactory.build(
                 positionFactory.build(i, 1, 0),
-                positionFactory.build((i + 1), 1, 0));
+                positionFactory.build(i + 1, 1, 0)
+            );
           default: // j > 1
             return stateFactory.build(
                 positionFactory.build(i, 1, 0),
-                positionFactory.build((i + 1), 1, 0),
-                positionFactory.build((i + j + 1), j, 0));
+                positionFactory.build(i + 1, 1, 0),
+                positionFactory.build(i + j + 1, j, 0)
+            );
         }
       }
 
       if (h == w - 1) {
         if (characteristicVector[h]) {
           return stateFactory.build(
-              positionFactory.build((i + 1), 0, 0));
+              positionFactory.build(i + 1, 0, 0)
+          );
         }
 
         return stateFactory.build(
             positionFactory.build(i, 1, 0),
-            positionFactory.build((i + 1), 1, 0));
+            positionFactory.build(i + 1, 1, 0)
+        );
       }
 
       // else, h == 2
       return stateFactory.build(
-          positionFactory.build(i, 1, 0));
+          positionFactory.build(i, 1, 0)
+      );
     }
 
     if (1 <= e && e < n) {
@@ -81,34 +88,39 @@ public class TranspositionPositionTransitionFunction
             ? n - e + 1
             : Integer.MAX_VALUE;
           final int b = w - h;
-          final int k = (a < b) ? a : b;
+          final int k = a < b ? a : b;
           final int j = indexOf(characteristicVector, k, h);
 
           switch (j) {
             case 0:
               return stateFactory.build(
-                  positionFactory.build((i + 1), e, 0));
+                  positionFactory.build(i + 1, e, 0)
+              );
             case 1:
               return stateFactory.build(
-                  positionFactory.build(i, (e + 1), 0),
-                  positionFactory.build(i, (e + 1), 1),
-                  positionFactory.build((i + 1), (e + 1), 0),
-                  positionFactory.build((i + 2), (e + 1), 0));
+                  positionFactory.build(i, e + 1, 0),
+                  positionFactory.build(i, e + 1, 1),
+                  positionFactory.build(i + 1, e + 1, 0),
+                  positionFactory.build(i + 2, e + 1, 0)
+              );
             case -1:
               return stateFactory.build(
-                  positionFactory.build(i, (e + 1), 0),
-                  positionFactory.build((i + 1), (e + 1), 0));
+                  positionFactory.build(i, e + 1, 0),
+                  positionFactory.build(i + 1, e + 1, 0)
+              );
             default: // j > 1
               return stateFactory.build(
-                  positionFactory.build(i, (e + 1), 0),
-                  positionFactory.build((i + 1), (e + 1), 0),
-                  positionFactory.build((i + j + 1), (e + j), 0));
+                  positionFactory.build(i, e + 1, 0),
+                  positionFactory.build(i + 1, e + 1, 0),
+                  positionFactory.build(i + j + 1, e + j, 0)
+              );
           }
         }
 
         if (characteristicVector[h]) {
           return stateFactory.build(
-              positionFactory.build((i + 2), e, 0));
+              positionFactory.build(i + 2, e, 0)
+          );
         }
 
         return null;
@@ -117,23 +129,27 @@ public class TranspositionPositionTransitionFunction
       if (h == w - 1) {
         if (characteristicVector[h]) {
           return stateFactory.build(
-              positionFactory.build((i + 1), e, 0));
+              positionFactory.build(i + 1, e, 0)
+          );
         }
 
         return stateFactory.build(
-            positionFactory.build(i, (e + 1), 0),
-            positionFactory.build((i + 1), (e + 1), 0));
+            positionFactory.build(i, e + 1, 0),
+            positionFactory.build(i + 1, e + 1, 0)
+        );
       }
 
       // else, h == w
       return stateFactory.build(
-          positionFactory.build(i, (e + 1), 0));
+          positionFactory.build(i, e + 1, 0)
+      );
     }
 
     if ((h <= w - 1) && (t == 0)) {
       if (characteristicVector[h]) {
         return stateFactory.build(
-            positionFactory.build((i + 1), n, 0));
+            positionFactory.build(i + 1, n, 0)
+        );
       }
 
       return null;
@@ -142,7 +158,8 @@ public class TranspositionPositionTransitionFunction
     if ((h <= w - 2) && (t == 1)) {
       if (characteristicVector[h]) {
         return stateFactory.build(
-            positionFactory.build((i + 2), n, 0));
+            positionFactory.build(i + 2, n, 0)
+        );
       }
 
       return null;

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/distance/AbstractMemoized.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/distance/AbstractMemoized.java
@@ -29,7 +29,7 @@ public abstract class AbstractMemoized implements IDistance<String>, Serializabl
    * Initializes the memoization map, etc.
    */
   public AbstractMemoized() {
-    memo = new Object2IntOpenHashMap<SymmetricImmutablePair<String>>();
+    memo = new Object2IntOpenHashMap<>();
     memo.defaultReturnValue(DEFAULT_RETURN_VALUE);
   }
 

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/factory/ElementFactory.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/factory/ElementFactory.java
@@ -22,7 +22,7 @@ public class ElementFactory<Type> implements IElementFactory<Type>, Serializable
    */
   @Override
   public Element<Type> build(final Type value) {
-    final Element<Type> element = new Element<Type>();
+    final Element<Type> element = new Element<>();
     element.value(value);
     return element;
   }

--- a/src/main/java/com/github/dylon/liblevenshtein/levenshtein/factory/TransducerBuilder.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/levenshtein/factory/TransducerBuilder.java
@@ -45,7 +45,8 @@ import com.github.dylon.liblevenshtein.levenshtein.XPositionDistanceFunction;
 @FieldDefaults(level=AccessLevel.PRIVATE)
 public class TransducerBuilder implements ITransducerBuilder, Serializable {
 
-	private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
+  public static final String UNSUPPORTED_ALGORITHM = "Unsupported Algorithm: ";
 
   /**
    * Builds and recycles {@link DawgNode} {@link com.github.dylon.liblevenshtein.collection.dawg.Prefix}es.
@@ -186,13 +187,13 @@ public class TransducerBuilder implements ITransducerBuilder, Serializable {
       	.includeDistance(includeDistance);
 
     final Transducer<DawgNode, CandidateType> transducer =
-    	new Transducer<DawgNode, CandidateType>(attributes);
+    	new Transducer<>(attributes);
 
     if (maxCandidates == Integer.MAX_VALUE) {
       return transducer;
     }
 
-    return new DeprecatedTransducerForLimitingNumberOfCandidates<CandidateType>(
+    return new DeprecatedTransducerForLimitingNumberOfCandidates<>(
     		maxCandidates,
     		transducer);
   }
@@ -210,7 +211,7 @@ public class TransducerBuilder implements ITransducerBuilder, Serializable {
       case MERGE_AND_SPLIT:
         return new XPositionDistanceFunction();
       default:
-        throw new IllegalArgumentException("Unsupported Algorithm: " + algorithm);
+        throw new IllegalArgumentException(UNSUPPORTED_ALGORITHM + algorithm);
     }
   }
 
@@ -228,7 +229,7 @@ public class TransducerBuilder implements ITransducerBuilder, Serializable {
       case MERGE_AND_SPLIT:
         return stateFactory.build(new int[] {0,0,0});
       default:
-        throw new IllegalArgumentException("Unsupported Algorithm: " + algorithm);
+        throw new IllegalArgumentException(UNSUPPORTED_ALGORITHM + algorithm);
     }
   }
 
@@ -288,7 +289,7 @@ public class TransducerBuilder implements ITransducerBuilder, Serializable {
               .positionFactory(positionFactory));
         break;
       default:
-        throw new IllegalArgumentException("Unsupported Algorithm: " + algorithm);
+        throw new IllegalArgumentException(UNSUPPORTED_ALGORITHM + algorithm);
     }
 
     positionTransitionFactory
@@ -352,7 +353,7 @@ public class TransducerBuilder implements ITransducerBuilder, Serializable {
         final ICandidateCollection<CandidateType> candidates) {
       return new ICandidateCollection<CandidateType>() {
         @Override public Iterator<CandidateType> iterator() {
-          return new TakeIterator<CandidateType>(elementsToTake, candidates.iterator());
+          return new TakeIterator<>(elementsToTake, candidates.iterator());
         }
       };
     }

--- a/src/main/java/com/github/dylon/liblevenshtein/serialization/ProtobufSerializer.java
+++ b/src/main/java/com/github/dylon/liblevenshtein/serialization/ProtobufSerializer.java
@@ -22,6 +22,7 @@ import com.github.dylon.liblevenshtein.levenshtein.factory.TransducerBuilder;
  */
 @SuppressWarnings("unchecked")
 public class ProtobufSerializer implements Serializer {
+  public static final String UNKNOWN_TYPE_S = "Unknown type [%s]";
 
   // Serializers
   // ---------------------------------------------------------------------------
@@ -84,7 +85,7 @@ public class ProtobufSerializer implements Serializer {
       return proto.toByteArray();
     }
 
-    final String message = String.format("Unknown type [%s]", object.getClass());
+    final String message = String.format(UNKNOWN_TYPE_S, object.getClass());
     throw new IllegalArgumentException(message);
   }
 
@@ -117,7 +118,7 @@ public class ProtobufSerializer implements Serializer {
       return (Type) modelOf(proto);
     }
 
-    final String message = String.format("Unknown type [%s]", type);
+    final String message = String.format(UNKNOWN_TYPE_S, type);
     throw new IllegalArgumentException(message);
   }
 
@@ -147,7 +148,7 @@ public class ProtobufSerializer implements Serializer {
       return (Type) modelOf(proto);
     }
 
-    final String message = String.format("Unknown type [%s]", type);
+    final String message = String.format(UNKNOWN_TYPE_S, type);
     throw new IllegalArgumentException(message);
   }
 

--- a/src/task/java/com/github/dylon/liblevenshtein/task/GenerateReadme.java
+++ b/src/task/java/com/github/dylon/liblevenshtein/task/GenerateReadme.java
@@ -22,7 +22,7 @@ public class GenerateReadme {
 
     final String gradleVersion = args[argsIdx ++];
     final String javaSourceVersion = args[argsIdx ++];
-    final String javaTargetVersion = args[argsIdx ++];
+    final String javaTargetVersion = args[argsIdx];
 
     final STGroup group = new STGroupDir("stringtemplate", '$', '$');
 

--- a/src/task/java/com/github/dylon/liblevenshtein/task/GenerateWikidoc.java
+++ b/src/task/java/com/github/dylon/liblevenshtein/task/GenerateWikidoc.java
@@ -22,7 +22,7 @@ public class GenerateWikidoc {
 
     final String gradleVersion = args[argsIdx ++];
     final String javaSourceVersion = args[argsIdx ++];
-    final String javaTargetVersion = args[argsIdx ++];
+    final String javaTargetVersion = args[argsIdx];
 
     final STGroup group = new STGroupDir("stringtemplate/wiki/", '$', '$');
 

--- a/src/test/java/com/github/dylon/liblevenshtein/collection/SymmetricImmutablePairTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/collection/SymmetricImmutablePairTest.java
@@ -49,6 +49,6 @@ public class SymmetricImmutablePairTest {
   public SymmetricImmutablePair<String> build(
       final String first,
       final String second) {
-    return new SymmetricImmutablePair<String>(first, second);
+    return new SymmetricImmutablePair<>(first, second);
   }
 }

--- a/src/test/java/com/github/dylon/liblevenshtein/collection/dawg/DawgTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/collection/dawg/DawgTest.java
@@ -47,22 +47,22 @@ public class DawgTest {
             getClass().getResourceAsStream("/resources/wordsEn.txt"),
             StandardCharsets.UTF_8))) {
 
-      final List<String> terms = new ArrayList<String>();
+      final List<String> termsList = new ArrayList<>();
 
       String term;
       while ((term = reader.readLine()) != null) {
-        terms.add(term);
+        termsList.add(term);
       }
 
-      Collections.sort(terms);
+      Collections.sort(termsList);
 
-      this.terms = terms;
+      this.terms = termsList;
       this.dawgNodeFactory = new DawgNodeFactory();
-      this.prefixFactory = new PrefixFactory<DawgNode>();
-      this.transitionFactory = new TransitionFactory<DawgNode>();
+      this.prefixFactory = new PrefixFactory<>();
+      this.transitionFactory = new TransitionFactory<>();
       this.dawgFactory = new DawgFactory(dawgNodeFactory, prefixFactory, transitionFactory);
-      this.emptyDawg = dawgFactory.build(new ArrayList<String>(0));
-      this.fullDawg = dawgFactory.build(terms);
+      this.emptyDawg = dawgFactory.build(new ArrayList<>(0));
+      this.fullDawg = dawgFactory.build(termsList);
     }
   }
 
@@ -112,39 +112,39 @@ public class DawgTest {
 
   @Test
   public void dawgAcceptsEmptyStringIfInTerms() {
-    final List<String> terms = new ArrayList<>(1);
-    terms.add("");
-    final AbstractDawg dawg = dawgFactory.build(terms);
+    final List<String> termsList = new ArrayList<>(1);
+    termsList.add("");
+    final AbstractDawg dawg = dawgFactory.build(termsList);
     assertTrue(dawg.contains(""));
   }
 
   @Test
   public void dawgShouldIterateOverAllTerms() {
-    final Set<String> terms = new HashSet<>(this.terms);
+    final Set<String> termsList = new HashSet<>(this.terms);
     for (final String term : fullDawg) {
       try {
-        assertTrue(terms.contains(term));
+        assertTrue(termsList.contains(term));
       }
       catch (final AssertionError exception) {
         throw new AssertionError("Expected terms to contain: \"" + term + "\"", exception);
       }
-      terms.remove(term);
+      termsList.remove(term);
     }
-    if (!terms.isEmpty()) {
+    if (!termsList.isEmpty()) {
       final String message =
         String.format("Expected all terms to be iterated over, but missed [%s]",
-          Joiner.on(", ").join(terms));
+          Joiner.on(", ").join(termsList));
       throw new AssertionError(message);
     }
   }
 
   @Test(expectedExceptions=IllegalArgumentException.class)
   public void insertingTermsOutOfOrderShouldThrowAnException() {
-    final List<String> terms = new ArrayList<>(3);
-    terms.add("a");
-    terms.add("c");
-    terms.add("b");
-    dawgFactory.build(terms, true);
+    final List<String> termsList = new ArrayList<>(3);
+    termsList.add("a");
+    termsList.add("c");
+    termsList.add("b");
+    dawgFactory.build(termsList, true);
   }
 
   @Test
@@ -169,9 +169,9 @@ public class DawgTest {
     @Override
     public Object[] next() {
       advance();
-      final Object[] params = this.params;
+      final Object[] paramsLocal = this.params;
       this.params = null;
-      return params;
+      return paramsLocal;
     }
 
     @Override

--- a/src/test/java/com/github/dylon/liblevenshtein/levenshtein/MergeAndSplitTransducerTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/levenshtein/MergeAndSplitTransducerTest.java
@@ -45,7 +45,7 @@ public class MergeAndSplitTransducerTest extends AbstractTransducerTest {
         .build();
     }
 
-    this.expectedCandidates = new HashSet<Candidate>();
+    this.expectedCandidates = new HashSet<>();
     expectedCandidates.add(new Candidate("A#", 2));
     expectedCandidates.add(new Candidate("A+", 2));
     expectedCandidates.add(new Candidate("Ada", 2));

--- a/src/test/java/com/github/dylon/liblevenshtein/levenshtein/StandardDistanceTransducerTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/levenshtein/StandardDistanceTransducerTest.java
@@ -44,7 +44,7 @@ public class StandardDistanceTransducerTest extends AbstractTransducerTest {
         .build();
     }
 
-    this.expectedCandidates = new HashSet<Candidate>();
+    this.expectedCandidates = new HashSet<>();
     expectedCandidates.add(new Candidate("Java", 2));
     expectedCandidates.add(new Candidate("Ada", 3));
     expectedCandidates.add(new Candidate("Agda", 3));

--- a/src/test/java/com/github/dylon/liblevenshtein/levenshtein/SubsumesFunctionTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/levenshtein/SubsumesFunctionTest.java
@@ -6,6 +6,10 @@ import static org.testng.Assert.assertEquals;
 
 public class SubsumesFunctionTest {
 
+  private final SubsumesFunction standardSubsumes = new SubsumesFunction.ForStandardAlgorithm();
+  private final SubsumesFunction transpositionSubsumes = new SubsumesFunction.ForTransposition();
+  private final SubsumesFunction mergeAndSplitSubsumes = new SubsumesFunction.ForMergeAndSplit();
+
   @DataProvider(name = "forStandardAlgorithm")
   public Object[][] forStandardAlgorithm() {
     return new Object[][] {
@@ -101,10 +105,6 @@ public class SubsumesFunctionTest {
     , {1,1,1, 1,1,1, 4, true}
     };
   }
-
-  private final SubsumesFunction standardSubsumes = new SubsumesFunction.ForStandardAlgorithm();
-  private final SubsumesFunction transpositionSubsumes = new SubsumesFunction.ForTransposition();
-  private final SubsumesFunction mergeAndSplitSubsumes = new SubsumesFunction.ForMergeAndSplit();
 
   @Test(dataProvider = "forStandardAlgorithm")
   public void testForStandardAlgorithm(

--- a/src/test/java/com/github/dylon/liblevenshtein/levenshtein/TranspositionTransducerTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/levenshtein/TranspositionTransducerTest.java
@@ -45,7 +45,7 @@ public class TranspositionTransducerTest extends AbstractTransducerTest {
         .build();
     }
 
-    this.expectedCandidates = new HashSet<Candidate>();
+    this.expectedCandidates = new HashSet<>();
     expectedCandidates.add(new Candidate("Java", 1));
     expectedCandidates.add(new Candidate("Lava", 2));
     expectedCandidates.add(new Candidate("Ada", 3));

--- a/src/test/java/com/github/dylon/liblevenshtein/levenshtein/UnsubsumeFunctionTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/levenshtein/UnsubsumeFunctionTest.java
@@ -74,7 +74,7 @@ public class UnsubsumeFunctionTest {
         standardPositionFactory.build(i,e),
         standardPositionFactory.build(j,f));
 
-    final IState expectedOutput = (shouldSubsume)
+    final IState expectedOutput = shouldSubsume
       ? stateFactory.build(
           standardPositionFactory.build(i,e))
       : stateFactory.build(
@@ -95,7 +95,7 @@ public class UnsubsumeFunctionTest {
         xPositionFactory.build(i,e,s),
         xPositionFactory.build(j,f,t));
 
-    final IState expectedOutput = (shouldSubsume)
+    final IState expectedOutput = shouldSubsume
       ? stateFactory.build(
           xPositionFactory.build(i,e,s))
       : stateFactory.build(

--- a/src/test/java/com/github/dylon/liblevenshtein/levenshtein/factory/MemoizedDistanceFactoryTest.java
+++ b/src/test/java/com/github/dylon/liblevenshtein/levenshtein/factory/MemoizedDistanceFactoryTest.java
@@ -30,14 +30,14 @@ public class MemoizedDistanceFactoryTest {
               "/resources/top-20-most-common-english-words.txt"),
             StandardCharsets.UTF_8))) {
 
-      final List<String> terms = new ArrayList<String>();
+      final List<String> termsList = new ArrayList<>();
 
       String term;
       while ((term = reader.readLine()) != null) {
-        terms.add(term);
+        termsList.add(term);
       }
 
-      this.terms = terms;
+      this.terms = termsList;
       this.factory = new MemoizedDistanceFactory();
     }
   }
@@ -158,9 +158,9 @@ public class MemoizedDistanceFactoryTest {
     @Override
     public Object[] next() {
       advance();
-      final Object[] params = this.params;
+      final Object[] paramsLocal = this.params;
       this.params = null;
-      return params;
+      return paramsLocal;
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:HiddenFieldCheck - Local variables should not shadow class fields. 
squid:S1192 - String literals should not be duplicated.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava