### PR TITLE
errors -> fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Bountysource][bountysource-badge]][bountysource-link]
 
 Levenshtein transducers accept a query term and return all terms in a
-dictionary that are within n spelling errors away from it. They constitute a
+dictionary that are within n spelling fixes away from it. They constitute a
 highly-efficient (space _and_ time) class of spelling correctors that work very
 well when you do not require context while making suggestions.  Forget about
 performing a linear scan over your dictionary to find all terms that are


### PR DESCRIPTION
Judging by [the example on GH pages](https://universal-automata.github.io/liblevenshtein/), it would seem that the output is in terms of "spelling *fixes*". The input, instead, is erroneous.